### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 -This is a Python Django application developed as my summer internship task in order to make tracking of the change of cryptocurrencies easy.
   Postgre Database is used in order to store the data.
   
--At the end Linear Regressioin is used to Predict the price using historical data.
+-At the end Linear Regression is used to Predict the price using historical data.
 
 -Dockerization is also added in order to both gain an experience in it and be able to run the program in any environment.


### PR DESCRIPTION
## Summary
- correct 'Regressioin' typo in README

## Testing
- `pytest -q`
- `python3 app/code/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867dacd27fc83268435e21288b7b3dc